### PR TITLE
build: standardize the way the crate support no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "num-modular"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2018"
 
 repository = "https://github.com/cmpute/num-modular"
@@ -16,24 +16,21 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num-integer = { version = "0.1.44", optional = true }
-num-traits = { version = "0.2.14", optional = true }
+num-integer = { version = "0.1.44", default_features = false, optional = true }
+num-traits = { version = "0.2.14", default_features = false, optional = true }
+num-bigint = { version = "0.4.3", default_features = false, optional = true }
 
-[dependencies.num-bigint]
-optional = true
-version = "0.4.3"
-default-features = false
 
 [dev-dependencies]
 rand = "0.8.4"
 
 [workspace]
-members = [
-  "bench",
-]
+members = ["bench"]
 
 [package.metadata.docs.rs]
 all-features = true
 
 [features]
-std = []
+default = ["std"]
+std = ["num-integer?/std", "num-traits?/std", "num-bigint?/std"]
+num-bigint = ["dep:num-bigint", "num-traits", "num-integer"]


### PR DESCRIPTION
`default = ["std"]`
build the crate with the `std` feature enabled by default

It's a breaking change because `std` will now be imported by default, and has to be manually disabled using `default-features = false`. It was previously only imported if the user manually enable it with `features = ["std"]`. We went from an `opt-in` to an `opt-out` logic, which is the standard way of treating `std` in the rust ecosystem.

`std = ["num-integer?/std", "num-traits?/std", "num-bigint?/std"]`
if the `std` feature is active, and for another reason you import one of the optional crate, it will be imported with it's own `std` feature enabled

`num-bigint = ["dep:num-bigint", "num-traits", "num-integer"]`
if the `num-bigint` feature is enabled, the tree optional crates will be loaded

More about this syntax [here](https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies) and [here](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features)



